### PR TITLE
fixed: nopointer validation

### DIFF
--- a/cmd/elegen/templates/model.gotpl
+++ b/cmd/elegen/templates/model.gotpl
@@ -454,9 +454,11 @@ func (o *{{ .Spec.Model.EntityName }}) Validate() error {
 
     {{ if or (eq .Type "refList") (eq .Type "refMap") }}
     for _, sub := range o.{{ .ConvertedName }} {
+        {{- if ne .Extensions.refMode "nopointer" }}
         if sub == nil {
             continue
         }
+        {{ end -}}
         elemental.ResetDefaultForZeroValues(sub)
         if err := sub.Validate(); err != nil {
             errors = errors.Append(err)


### PR DESCRIPTION
If an attribute type was "refList" with the extension "refMode: nopointer" set, the generator was adding invalid validation code in model.

This patches makes the code generation skip the validation

@CyrilPeponnet  @chris-acuvity  this will need you to update elegen in your toolchain