### PR TITLE
openapi: introduces OpenAPI generator specific extensions

### DIFF
--- a/cmd/internal/genopenapi3/extensions.go
+++ b/cmd/internal/genopenapi3/extensions.go
@@ -1,0 +1,113 @@
+package genopenapi3
+
+import "fmt"
+
+const (
+	pathExtensionName              = "openapi_path"
+	responseMapExtensionName       = "openapi_response_map"
+	componentRegistryExtensionName = "openapi_component_registry"
+)
+
+type responseSpec struct {
+	Spec        string
+	IsArray     bool
+	Description string
+}
+
+func getPathExtension(extensions map[string]any) (string, bool) {
+
+	if extensions == nil {
+		return "", false
+	}
+
+	entry, ok := extensions[pathExtensionName]
+	if !ok {
+		return "", false
+	}
+
+	path, ok := entry.(string)
+	if !ok {
+		panic(fmt.Sprintf("invalid %s extension: expected type string, got %T", pathExtensionName, path))
+	}
+	return path, true
+}
+
+func getResponseMapExtension(extensions map[string]any) (map[string]responseSpec, bool) {
+
+	if extensions == nil {
+		return nil, false
+	}
+
+	entry, ok := extensions[responseMapExtensionName]
+	if !ok {
+		return nil, false
+	}
+
+	responseMap, ok := entry.(map[string]any)
+	if !ok {
+		panic(fmt.Sprintf("invalid %s extension: status code: expected type map[string]any, got %T", responseMapExtensionName, entry))
+	}
+	ret := make(map[string]responseSpec, len(responseMap))
+	for statusCode, responseEntry := range responseMap {
+		responseEntryMap, ok := responseEntry.(map[string]any)
+		if !ok {
+			panic(fmt.Sprintf("invalid %s extension entry: response spec: expected type map[string]any, got %T", responseMapExtensionName, responseEntry))
+		}
+		specEntry, ok := responseEntryMap["spec"]
+		if !ok {
+			panic(fmt.Sprintf("invalid %s extension entry: response spec: missing 'spec' key", responseMapExtensionName))
+		}
+		spec, ok := specEntry.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid %s extension entry: response spec: 'spec' key: expected type string, got %T", responseMapExtensionName, specEntry))
+		}
+		description := ""
+		if descEntry, ok := responseEntryMap["description"]; ok {
+			desc, ok := descEntry.(string)
+			if !ok {
+				panic(fmt.Sprintf("invalid %s extension entry: response spec: 'description' key: expected type string, got %T", responseMapExtensionName, descEntry))
+			}
+			description = desc
+		}
+		isArray := false
+		if isArrayEntry, ok := responseEntryMap["is_array"]; ok {
+			isArray, ok = isArrayEntry.(bool)
+			if !ok {
+				panic(fmt.Sprintf("invalid %s extension entry: response spec: 'is_array' key: expected type bool, got %T", responseMapExtensionName, isArrayEntry))
+			}
+		}
+		ret[statusCode] = responseSpec{
+			Spec:        spec,
+			IsArray:     isArray,
+			Description: description,
+		}
+	}
+	return ret, true
+}
+
+func getComponentRegistryExtension(extensions map[string]any) ([]string, bool) {
+
+	if extensions == nil {
+		return nil, false
+	}
+
+	entry, ok := extensions[componentRegistryExtensionName]
+	if !ok {
+		return nil, false
+	}
+
+	typesUntyped, ok := entry.([]any)
+	if !ok {
+		panic(fmt.Sprintf("invalid %s extension: expected type []any, got %T", componentRegistryExtensionName, entry))
+	}
+	types := make([]string, len(typesUntyped))
+	for i, typ := range typesUntyped {
+		typStr, ok := typ.(string)
+		if !ok {
+			panic(fmt.Sprintf("invalid %s extension entry: expected type string, got %T", componentRegistryExtensionName, typ))
+		}
+		types[i] = typStr
+	}
+
+	return types, true
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.acuvity.ai/elemental
 
 go 1.21
 
-require go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0
+require go.acuvity.ai/regolithe v0.0.0-20241029211939-d9b92285c6f7
 
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0 h1:MDiI30Cy8qThG2nsOGdPmIPBUHqwN81BjtwdwNXqsrI=
-go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0/go.mod h1:UnBKO2jcC7uYgmH7h/yNLo1iD3A3lsbG7zr3JmqRPl8=
+go.acuvity.ai/regolithe v0.0.0-20241029211939-d9b92285c6f7 h1:o4N7UKQYEH/BweBHK98gtiMyCY3NiGi7rM8xH8mErQw=
+go.acuvity.ai/regolithe v0.0.0-20241029211939-d9b92285c6f7/go.mod h1:UnBKO2jcC7uYgmH7h/yNLo1iD3A3lsbG7zr3JmqRPl8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=


### PR DESCRIPTION
When we generate OpenAPI specs we naturally assume that this is always a proper REST endpoint that we are dealing with. However, to be more flexible on POSTs, these PR introduces OpenAPI generator specifc extensions:

This commit makes use of the generic extensions in regolithe specs. It introduces three OpenAPI generator specific extensions in the Model, Relation and RelationAction extensions field:

- `openapi_path`: Allows to override the generated URI path for a resource and its operation. Works in the relation and model extensions.
- `openapi_component_registry`: Allows to register external type definitions/mappings within the component schemas of the generated OpenAPI spec. Works on model extensions.
- `openapi_response_map`: Allows to define a map of HTTP status codes and their response types together with a description. If not provided, it will still always generate a default response for the HTTP 200 status code as before. Works on relation action extensions.

Requires https://github.com/acuvity/regolithe/pull/3