### PR TITLE
testmodels: add ref, refmap and reflist to test list

### DIFF
--- a/attribute_test.go
+++ b/attribute_test.go
@@ -79,14 +79,52 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 		l := NewList()
 		l.Secret = "it's a secret to everybody"
 
-		Convey("When I call ResetSecretAttributesValues", func() {
+		ResetSecretAttributesValues(l)
 
-			ResetSecretAttributesValues(l)
+		So(l.Secret, ShouldEqual, "")
+	})
 
-			Convey("Then the secret should have been erased", func() {
-				So(l.Secret, ShouldEqual, "")
-			})
-		})
+	Convey("Given I have an identifiable with a ref with secret property", t, func() {
+
+		l := NewList()
+		l.Ref = NewTask()
+		l.Ref.Secret = "it's a secret to everybody"
+
+		ResetSecretAttributesValues(l)
+
+		So(l.Ref.Secret, ShouldEqual, "")
+	})
+
+	Convey("Given I have an identifiable with a refList with secret property", t, func() {
+
+		l := NewList()
+		l.RefList = TasksList{
+			NewTask(),
+			NewTask(),
+		}
+		l.RefList[0].Secret = "it's a secret to everybody"
+		l.RefList[1].Secret = "it's a secret to everybody"
+
+		ResetSecretAttributesValues(l)
+
+		So(l.RefList[0].Secret, ShouldEqual, "")
+		So(l.RefList[1].Secret, ShouldEqual, "")
+	})
+
+	Convey("Given I have an identifiable with a refMap with secret property", t, func() {
+
+		l := NewList()
+		l.RefMap = map[string]*Task{
+			"a": NewTask(),
+			"b": NewTask(),
+		}
+		l.RefMap["a"].Secret = "it's a secret to everybody"
+		l.RefMap["b"].Secret = "it's a secret to everybody"
+
+		ResetSecretAttributesValues(l)
+
+		So(l.RefMap["a"].Secret, ShouldEqual, "")
+		So(l.RefMap["b"].Secret, ShouldEqual, "")
 	})
 
 	Convey("Given I have some identifiables with a secret property", t, func() {
@@ -97,15 +135,10 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 		l2 := NewList()
 		l2.Secret = "it's a secret to everybody"
 
-		Convey("When I call ResetSecretAttributesValues", func() {
+		ResetSecretAttributesValues(ListsList{l1, l2})
 
-			ResetSecretAttributesValues(ListsList{l1, l2})
-
-			Convey("Then the secret should have been erased", func() {
-				So(l1.Secret, ShouldEqual, "")
-				So(l2.Secret, ShouldEqual, "")
-			})
-		})
+		So(l1.Secret, ShouldEqual, "")
+		So(l2.Secret, ShouldEqual, "")
 	})
 
 	Convey("Given I have an sparse identifiable with a secret property", t, func() {
@@ -115,14 +148,9 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 		l := NewSparseList()
 		l.Secret = &val
 
-		Convey("When I call ResetSecretAttributesValues", func() {
+		ResetSecretAttributesValues(l)
 
-			ResetSecretAttributesValues(l)
-
-			Convey("Then the secret should have been erased", func() {
-				So(l.Secret, ShouldBeNil)
-			})
-		})
+		So(l.Secret, ShouldBeNil)
 	})
 
 	Convey("Given I have some sparse identifiables with a secret property", t, func() {
@@ -135,63 +163,36 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 		val2 := "it's a secret to everybody"
 		l2.Secret = &val2
 
-		Convey("When I call ResetSecretAttributesValues", func() {
+		ResetSecretAttributesValues(SparseListsList{l1, l2})
 
-			ResetSecretAttributesValues(SparseListsList{l1, l2})
-
-			Convey("Then the secret should have been erased", func() {
-				So(l1.Secret, ShouldBeNil)
-				So(l2.Secret, ShouldBeNil)
-			})
-		})
+		So(l1.Secret, ShouldBeNil)
+		So(l2.Secret, ShouldBeNil)
 	})
 
 	Convey("Given I have some random non pointer struct", t, func() {
-
 		s := struct{}{}
 
-		Convey("When I call ResetSecretAttributesValues", func() {
-
-			ResetSecretAttributesValues(s)
-
-			Convey("Then it should not panic", func() {
-				So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
-			})
-		})
+		ResetSecretAttributesValues(s)
+		So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
 	})
 
 	Convey("Given I have some random pointer struct", t, func() {
-
 		s := &struct{}{}
-
-		Convey("Then it should not panic", func() {
-			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
-		})
+		So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
 	})
 
 	Convey("Given I have some nil pointer struct", t, func() {
-
 		var s *struct{}
-
-		Convey("Then it should not panic", func() {
-			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
-		})
+		So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
 	})
 
 	Convey("Given I have some nil value", t, func() {
-
-		Convey("Then it should not panic", func() {
-			So(func() { ResetSecretAttributesValues(nil) }, ShouldNotPanic)
-		})
+		So(func() { ResetSecretAttributesValues(nil) }, ShouldNotPanic)
 	})
 
 	Convey("Given I have some nil pointer identifiable", t, func() {
-
 		var s *List
-
-		Convey("Then it should not panic", func() {
-			So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
-		})
+		So(func() { ResetSecretAttributesValues(s) }, ShouldNotPanic)
 	})
 
 	Convey("Given I have an non pointer identifiable with a secret property", t, func() {
@@ -199,14 +200,8 @@ func Test_ResetSecretAttributesValues(t *testing.T) {
 		l := NewList()
 		l.Secret = "it's a secret to everybody"
 
-		Convey("When I call ResetSecretAttributesValues", func() {
-
-			ResetSecretAttributesValues(*l)
-
-			Convey("Then the secret should have been erased", func() {
-				So(l.Secret, ShouldEqual, "it's a secret to everybody")
-			})
-		})
+		ResetSecretAttributesValues(*l)
+		So(l.Secret, ShouldEqual, "it's a secret to everybody")
 	})
 }
 

--- a/data_test.go
+++ b/data_test.go
@@ -106,6 +106,15 @@ type List struct {
 	// This attribute is readonly.
 	ReadOnly string `json:"readOnly" msgpack:"readOnly" bson:"readonly" mapstructure:"readOnly,omitempty"`
 
+	// This attribute is a ref to a single object.
+	Ref *Task `json:"-" msgpack:"-" bson:"ref" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref to a objects.
+	RefList TasksList `json:"-" msgpack:"-" bson:"reflist" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref map to a objects.
+	RefMap map[string]*Task `json:"-" msgpack:"-" bson:"refmap" mapstructure:"-,omitempty"`
+
 	// This attribute is secret.
 	Secret string `json:"secret" msgpack:"secret" bson:"secret" mapstructure:"secret,omitempty"`
 
@@ -123,6 +132,9 @@ func NewList() *List {
 
 	return &List{
 		ModelVersion: 1,
+		Ref:          NewTask(),
+		RefList:      TasksList{},
+		RefMap:       map[string]*Task{},
 		Slice:        []string{},
 	}
 }
@@ -165,6 +177,9 @@ func (o *List) GetBSON() (any, error) {
 	s.ParentID = o.ParentID
 	s.ParentType = o.ParentType
 	s.ReadOnly = o.ReadOnly
+	s.Ref = o.Ref
+	s.RefList = o.RefList
+	s.RefMap = o.RefMap
 	s.Secret = o.Secret
 	s.Slice = o.Slice
 	s.Unexposed = o.Unexposed
@@ -193,6 +208,9 @@ func (o *List) SetBSON(raw bson.Raw) error {
 	o.ParentID = s.ParentID
 	o.ParentType = s.ParentType
 	o.ReadOnly = s.ReadOnly
+	o.Ref = s.Ref
+	o.RefList = s.RefList
+	o.RefMap = s.RefMap
 	o.Secret = s.Secret
 	o.Slice = s.Slice
 	o.Unexposed = s.Unexposed
@@ -256,6 +274,9 @@ func (o *List) ToSparse(fields ...string) SparseIdentifiable {
 			ParentID:     &o.ParentID,
 			ParentType:   &o.ParentType,
 			ReadOnly:     &o.ReadOnly,
+			Ref:          o.Ref,
+			RefList:      &o.RefList,
+			RefMap:       &o.RefMap,
 			Secret:       &o.Secret,
 			Slice:        &o.Slice,
 			Unexposed:    &o.Unexposed,
@@ -281,6 +302,12 @@ func (o *List) ToSparse(fields ...string) SparseIdentifiable {
 			sp.ParentType = &(o.ParentType)
 		case "readOnly":
 			sp.ReadOnly = &(o.ReadOnly)
+		case "ref":
+			sp.Ref = o.Ref
+		case "refList":
+			sp.RefList = &(o.RefList)
+		case "refMap":
+			sp.RefMap = &(o.RefMap)
 		case "secret":
 			sp.Secret = &(o.Secret)
 		case "slice":
@@ -323,6 +350,15 @@ func (o *List) Patch(sparse SparseIdentifiable) {
 	}
 	if so.ReadOnly != nil {
 		o.ReadOnly = *so.ReadOnly
+	}
+	if so.Ref != nil {
+		o.Ref = so.Ref
+	}
+	if so.RefList != nil {
+		o.RefList = *so.RefList
+	}
+	if so.RefMap != nil {
+		o.RefMap = *so.RefMap
 	}
 	if so.Secret != nil {
 		o.Secret = *so.Secret
@@ -419,6 +455,12 @@ func (o *List) ValueForAttribute(name string) any {
 		return o.ParentType
 	case "readOnly":
 		return o.ReadOnly
+	case "ref":
+		return o.Ref
+	case "refList":
+		return o.RefList
+	case "refMap":
+		return o.RefMap
 	case "secret":
 		return o.Secret
 	case "slice":
@@ -541,6 +583,42 @@ var ListAttributesMap = map[string]AttributeSpecification{
 		ReadOnly:       true,
 		Stored:         true,
 		Type:           "string",
+	},
+	"Ref": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ref",
+		ConvertedName:  "Ref",
+		Description:    `This attribute is a ref to a single object.`,
+		Filterable:     true,
+		Name:           "ref",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "ref",
+	},
+	"RefList": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "reflist",
+		ConvertedName:  "RefList",
+		Description:    `This attribute is a ref to a objects.`,
+		Filterable:     true,
+		Name:           "refList",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refList",
+	},
+	"RefMap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "refmap",
+		ConvertedName:  "RefMap",
+		Description:    `This attribute is a ref map to a objects.`,
+		Filterable:     true,
+		Name:           "refMap",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refMap",
 	},
 	"Secret": {
 		AllowedChoices: []string{},
@@ -693,6 +771,42 @@ var ListLowerCaseAttributesMap = map[string]AttributeSpecification{
 		Stored:         true,
 		Type:           "string",
 	},
+	"ref": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ref",
+		ConvertedName:  "Ref",
+		Description:    `This attribute is a ref to a single object.`,
+		Filterable:     true,
+		Name:           "ref",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "ref",
+	},
+	"reflist": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "reflist",
+		ConvertedName:  "RefList",
+		Description:    `This attribute is a ref to a objects.`,
+		Filterable:     true,
+		Name:           "refList",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refList",
+	},
+	"refmap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "refmap",
+		ConvertedName:  "RefMap",
+		Description:    `This attribute is a ref map to a objects.`,
+		Filterable:     true,
+		Name:           "refMap",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refMap",
+	},
 	"secret": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "secret",
@@ -819,6 +933,15 @@ type SparseList struct {
 	// This attribute is readonly.
 	ReadOnly *string `json:"readOnly,omitempty" msgpack:"readOnly,omitempty" bson:"readonly,omitempty" mapstructure:"readOnly,omitempty"`
 
+	// This attribute is a ref to a single object.
+	Ref *Task `json:"-" msgpack:"-" bson:"ref,omitempty" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref to a objects.
+	RefList *TasksList `json:"-" msgpack:"-" bson:"reflist,omitempty" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref map to a objects.
+	RefMap *map[string]*Task `json:"-" msgpack:"-" bson:"refmap,omitempty" mapstructure:"-,omitempty"`
+
 	// This attribute is secret.
 	Secret *string `json:"secret,omitempty" msgpack:"secret,omitempty" bson:"secret,omitempty" mapstructure:"secret,omitempty"`
 
@@ -895,6 +1018,15 @@ func (o *SparseList) GetBSON() (any, error) {
 	if o.ReadOnly != nil {
 		s.ReadOnly = o.ReadOnly
 	}
+	if o.Ref != nil {
+		s.Ref = o.Ref
+	}
+	if o.RefList != nil {
+		s.RefList = o.RefList
+	}
+	if o.RefMap != nil {
+		s.RefMap = o.RefMap
+	}
 	if o.Secret != nil {
 		s.Secret = o.Secret
 	}
@@ -944,6 +1076,15 @@ func (o *SparseList) SetBSON(raw bson.Raw) error {
 	if s.ReadOnly != nil {
 		o.ReadOnly = s.ReadOnly
 	}
+	if s.Ref != nil {
+		o.Ref = s.Ref
+	}
+	if s.RefList != nil {
+		o.RefList = s.RefList
+	}
+	if s.RefMap != nil {
+		o.RefMap = s.RefMap
+	}
 	if s.Secret != nil {
 		o.Secret = s.Secret
 	}
@@ -990,6 +1131,15 @@ func (o *SparseList) ToPlain() PlainIdentifiable {
 	}
 	if o.ReadOnly != nil {
 		out.ReadOnly = *o.ReadOnly
+	}
+	if o.Ref != nil {
+		out.Ref = o.Ref
+	}
+	if o.RefList != nil {
+		out.RefList = *o.RefList
+	}
+	if o.RefMap != nil {
+		out.RefMap = *o.RefMap
 	}
 	if o.Secret != nil {
 		out.Secret = *o.Secret
@@ -1045,30 +1195,36 @@ func (o *SparseList) DeepCopyInto(out *SparseList) {
 }
 
 type mongoAttributesList struct {
-	ID           bson.ObjectId `bson:"_id,omitempty"`
-	CreationOnly string        `bson:"creationonly"`
-	Date         time.Time     `bson:"date"`
-	Description  string        `bson:"description"`
-	Name         string        `bson:"name"`
-	ParentID     string        `bson:"parentid"`
-	ParentType   string        `bson:"parenttype"`
-	ReadOnly     string        `bson:"readonly"`
-	Secret       string        `bson:"secret"`
-	Slice        []string      `bson:"slice"`
-	Unexposed    string        `bson:"unexposed"`
+	ID           bson.ObjectId    `bson:"_id,omitempty"`
+	CreationOnly string           `bson:"creationonly"`
+	Date         time.Time        `bson:"date"`
+	Description  string           `bson:"description"`
+	Name         string           `bson:"name"`
+	ParentID     string           `bson:"parentid"`
+	ParentType   string           `bson:"parenttype"`
+	ReadOnly     string           `bson:"readonly"`
+	Ref          *Task            `bson:"ref"`
+	RefList      TasksList        `bson:"reflist"`
+	RefMap       map[string]*Task `bson:"refmap"`
+	Secret       string           `bson:"secret"`
+	Slice        []string         `bson:"slice"`
+	Unexposed    string           `bson:"unexposed"`
 }
 type mongoAttributesSparseList struct {
-	ID           bson.ObjectId `bson:"_id,omitempty"`
-	CreationOnly *string       `bson:"creationonly,omitempty"`
-	Date         *time.Time    `bson:"date,omitempty"`
-	Description  *string       `bson:"description,omitempty"`
-	Name         *string       `bson:"name,omitempty"`
-	ParentID     *string       `bson:"parentid,omitempty"`
-	ParentType   *string       `bson:"parenttype,omitempty"`
-	ReadOnly     *string       `bson:"readonly,omitempty"`
-	Secret       *string       `bson:"secret,omitempty"`
-	Slice        *[]string     `bson:"slice,omitempty"`
-	Unexposed    *string       `bson:"unexposed,omitempty"`
+	ID           bson.ObjectId     `bson:"_id,omitempty"`
+	CreationOnly *string           `bson:"creationonly,omitempty"`
+	Date         *time.Time        `bson:"date,omitempty"`
+	Description  *string           `bson:"description,omitempty"`
+	Name         *string           `bson:"name,omitempty"`
+	ParentID     *string           `bson:"parentid,omitempty"`
+	ParentType   *string           `bson:"parenttype,omitempty"`
+	ReadOnly     *string           `bson:"readonly,omitempty"`
+	Ref          *Task             `bson:"ref,omitempty"`
+	RefList      *TasksList        `bson:"reflist,omitempty"`
+	RefMap       *map[string]*Task `bson:"refmap,omitempty"`
+	Secret       *string           `bson:"secret,omitempty"`
+	Slice        *[]string         `bson:"slice,omitempty"`
+	Unexposed    *string           `bson:"unexposed,omitempty"`
 }
 
 // TaskStatusValue represents the possible values for attribute "status".
@@ -1172,6 +1328,9 @@ type Task struct {
 	// The type of the parent of the object.
 	ParentType string `json:"parentType" msgpack:"parentType" bson:"parenttype" mapstructure:"parentType,omitempty"`
 
+	// This attribute is secret.
+	Secret string `json:"secret" msgpack:"secret" bson:"secret" mapstructure:"secret,omitempty"`
+
 	// The status of the task.
 	Status TaskStatusValue `json:"status" msgpack:"status" bson:"status" mapstructure:"status,omitempty"`
 
@@ -1222,6 +1381,7 @@ func (o *Task) GetBSON() (any, error) {
 	s.Name = o.Name
 	s.ParentID = o.ParentID
 	s.ParentType = o.ParentType
+	s.Secret = o.Secret
 	s.Status = o.Status
 
 	return s, nil
@@ -1245,6 +1405,7 @@ func (o *Task) SetBSON(raw bson.Raw) error {
 	o.Name = s.Name
 	o.ParentID = s.ParentID
 	o.ParentType = s.ParentType
+	o.Secret = s.Secret
 	o.Status = s.Status
 
 	return nil
@@ -1303,6 +1464,7 @@ func (o *Task) ToSparse(fields ...string) SparseIdentifiable {
 			Name:        &o.Name,
 			ParentID:    &o.ParentID,
 			ParentType:  &o.ParentType,
+			Secret:      &o.Secret,
 			Status:      &o.Status,
 		}
 	}
@@ -1320,6 +1482,8 @@ func (o *Task) ToSparse(fields ...string) SparseIdentifiable {
 			sp.ParentID = &(o.ParentID)
 		case "parentType":
 			sp.ParentType = &(o.ParentType)
+		case "secret":
+			sp.Secret = &(o.Secret)
 		case "status":
 			sp.Status = &(o.Status)
 		}
@@ -1349,6 +1513,9 @@ func (o *Task) Patch(sparse SparseIdentifiable) {
 	}
 	if so.ParentType != nil {
 		o.ParentType = *so.ParentType
+	}
+	if so.Secret != nil {
+		o.Secret = *so.Secret
 	}
 	if so.Status != nil {
 		o.Status = *so.Status
@@ -1437,6 +1604,8 @@ func (o *Task) ValueForAttribute(name string) any {
 		return o.ParentID
 	case "parentType":
 		return o.ParentType
+	case "secret":
+		return o.Secret
 	case "status":
 		return o.Status
 	}
@@ -1515,6 +1684,19 @@ var TaskAttributesMap = map[string]AttributeSpecification{
 		Name:           "parentType",
 		Orderable:      true,
 		ReadOnly:       true,
+		Stored:         true,
+		Type:           "string",
+	},
+	"Secret": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "secret",
+		ConvertedName:  "Secret",
+		Description:    `This attribute is secret.`,
+		Exposed:        true,
+		Filterable:     true,
+		Name:           "secret",
+		Orderable:      true,
+		Secret:         true,
 		Stored:         true,
 		Type:           "string",
 	},
@@ -1604,6 +1786,19 @@ var TaskLowerCaseAttributesMap = map[string]AttributeSpecification{
 		Name:           "parentType",
 		Orderable:      true,
 		ReadOnly:       true,
+		Stored:         true,
+		Type:           "string",
+	},
+	"secret": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "secret",
+		ConvertedName:  "Secret",
+		Description:    `This attribute is secret.`,
+		Exposed:        true,
+		Filterable:     true,
+		Name:           "secret",
+		Orderable:      true,
+		Secret:         true,
 		Stored:         true,
 		Type:           "string",
 	},
@@ -1700,6 +1895,9 @@ type SparseTask struct {
 	// The type of the parent of the object.
 	ParentType *string `json:"parentType,omitempty" msgpack:"parentType,omitempty" bson:"parenttype,omitempty" mapstructure:"parentType,omitempty"`
 
+	// This attribute is secret.
+	Secret *string `json:"secret,omitempty" msgpack:"secret,omitempty" bson:"secret,omitempty" mapstructure:"secret,omitempty"`
+
 	// The status of the task.
 	Status *TaskStatusValue `json:"status,omitempty" msgpack:"status,omitempty" bson:"status,omitempty" mapstructure:"status,omitempty"`
 
@@ -1761,6 +1959,9 @@ func (o *SparseTask) GetBSON() (any, error) {
 	if o.ParentType != nil {
 		s.ParentType = o.ParentType
 	}
+	if o.Secret != nil {
+		s.Secret = o.Secret
+	}
 	if o.Status != nil {
 		s.Status = o.Status
 	}
@@ -1795,6 +1996,9 @@ func (o *SparseTask) SetBSON(raw bson.Raw) error {
 	if s.ParentType != nil {
 		o.ParentType = s.ParentType
 	}
+	if s.Secret != nil {
+		o.Secret = s.Secret
+	}
 	if s.Status != nil {
 		o.Status = s.Status
 	}
@@ -1826,6 +2030,9 @@ func (o *SparseTask) ToPlain() PlainIdentifiable {
 	}
 	if o.ParentType != nil {
 		out.ParentType = *o.ParentType
+	}
+	if o.Secret != nil {
+		out.Secret = *o.Secret
 	}
 	if o.Status != nil {
 		out.Status = *o.Status
@@ -1880,6 +2087,7 @@ type mongoAttributesTask struct {
 	Name        string          `bson:"name"`
 	ParentID    string          `bson:"parentid"`
 	ParentType  string          `bson:"parenttype"`
+	Secret      string          `bson:"secret"`
 	Status      TaskStatusValue `bson:"status"`
 }
 type mongoAttributesSparseTask struct {
@@ -1888,6 +2096,7 @@ type mongoAttributesSparseTask struct {
 	Name        *string          `bson:"name,omitempty"`
 	ParentID    *string          `bson:"parentid,omitempty"`
 	ParentType  *string          `bson:"parenttype,omitempty"`
+	Secret      *string          `bson:"secret,omitempty"`
 	Status      *TaskStatusValue `bson:"status,omitempty"`
 }
 var UnmarshalableListIdentity = Identity{Name: "list", Category: "lists"}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.acuvity.ai/elemental
 
 go 1.21
 
-require go.acuvity.ai/regolithe v0.0.0-20240402174917-1d6a5d4961ae
+require go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0
 
 require (
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de

--- a/go.sum
+++ b/go.sum
@@ -290,8 +290,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-go.acuvity.ai/regolithe v0.0.0-20240402174917-1d6a5d4961ae h1:+0/KUM9ux3PAK7e306JUYThoPAOQwlpOpPmORJmQs18=
-go.acuvity.ai/regolithe v0.0.0-20240402174917-1d6a5d4961ae/go.mod h1:UnBKO2jcC7uYgmH7h/yNLo1iD3A3lsbG7zr3JmqRPl8=
+go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0 h1:MDiI30Cy8qThG2nsOGdPmIPBUHqwN81BjtwdwNXqsrI=
+go.acuvity.ai/regolithe v0.0.0-20241028171033-7fadd70131d0/go.mod h1:UnBKO2jcC7uYgmH7h/yNLo1iD3A3lsbG7zr3JmqRPl8=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/test/model/list.go
+++ b/test/model/list.go
@@ -108,6 +108,15 @@ type List struct {
 	// This attribute is readonly.
 	ReadOnly string `json:"readOnly" msgpack:"readOnly" bson:"readonly" mapstructure:"readOnly,omitempty"`
 
+	// This attribute is a ref to a single object.
+	Ref *Task `json:"-" msgpack:"-" bson:"ref" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref to a objects.
+	RefList TasksList `json:"-" msgpack:"-" bson:"reflist" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref map to a objects.
+	RefMap map[string]*Task `json:"-" msgpack:"-" bson:"refmap" mapstructure:"-,omitempty"`
+
 	// This attribute is secret.
 	Secret string `json:"secret" msgpack:"secret" bson:"secret" mapstructure:"secret,omitempty"`
 
@@ -125,6 +134,9 @@ func NewList() *List {
 
 	return &List{
 		ModelVersion: 1,
+		Ref:          NewTask(),
+		RefList:      TasksList{},
+		RefMap:       map[string]*Task{},
 		Slice:        []string{},
 	}
 }
@@ -167,6 +179,9 @@ func (o *List) GetBSON() (any, error) {
 	s.ParentID = o.ParentID
 	s.ParentType = o.ParentType
 	s.ReadOnly = o.ReadOnly
+	s.Ref = o.Ref
+	s.RefList = o.RefList
+	s.RefMap = o.RefMap
 	s.Secret = o.Secret
 	s.Slice = o.Slice
 	s.Unexposed = o.Unexposed
@@ -195,6 +210,9 @@ func (o *List) SetBSON(raw bson.Raw) error {
 	o.ParentID = s.ParentID
 	o.ParentType = s.ParentType
 	o.ReadOnly = s.ReadOnly
+	o.Ref = s.Ref
+	o.RefList = s.RefList
+	o.RefMap = s.RefMap
 	o.Secret = s.Secret
 	o.Slice = s.Slice
 	o.Unexposed = s.Unexposed
@@ -258,6 +276,9 @@ func (o *List) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			ParentID:     &o.ParentID,
 			ParentType:   &o.ParentType,
 			ReadOnly:     &o.ReadOnly,
+			Ref:          o.Ref,
+			RefList:      &o.RefList,
+			RefMap:       &o.RefMap,
 			Secret:       &o.Secret,
 			Slice:        &o.Slice,
 			Unexposed:    &o.Unexposed,
@@ -283,6 +304,12 @@ func (o *List) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			sp.ParentType = &(o.ParentType)
 		case "readOnly":
 			sp.ReadOnly = &(o.ReadOnly)
+		case "ref":
+			sp.Ref = o.Ref
+		case "refList":
+			sp.RefList = &(o.RefList)
+		case "refMap":
+			sp.RefMap = &(o.RefMap)
 		case "secret":
 			sp.Secret = &(o.Secret)
 		case "slice":
@@ -325,6 +352,15 @@ func (o *List) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.ReadOnly != nil {
 		o.ReadOnly = *so.ReadOnly
+	}
+	if so.Ref != nil {
+		o.Ref = so.Ref
+	}
+	if so.RefList != nil {
+		o.RefList = *so.RefList
+	}
+	if so.RefMap != nil {
+		o.RefMap = *so.RefMap
 	}
 	if so.Secret != nil {
 		o.Secret = *so.Secret
@@ -421,6 +457,12 @@ func (o *List) ValueForAttribute(name string) any {
 		return o.ParentType
 	case "readOnly":
 		return o.ReadOnly
+	case "ref":
+		return o.Ref
+	case "refList":
+		return o.RefList
+	case "refMap":
+		return o.RefMap
 	case "secret":
 		return o.Secret
 	case "slice":
@@ -543,6 +585,42 @@ var ListAttributesMap = map[string]elemental.AttributeSpecification{
 		ReadOnly:       true,
 		Stored:         true,
 		Type:           "string",
+	},
+	"Ref": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ref",
+		ConvertedName:  "Ref",
+		Description:    `This attribute is a ref to a single object.`,
+		Filterable:     true,
+		Name:           "ref",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "ref",
+	},
+	"RefList": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "reflist",
+		ConvertedName:  "RefList",
+		Description:    `This attribute is a ref to a objects.`,
+		Filterable:     true,
+		Name:           "refList",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refList",
+	},
+	"RefMap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "refmap",
+		ConvertedName:  "RefMap",
+		Description:    `This attribute is a ref map to a objects.`,
+		Filterable:     true,
+		Name:           "refMap",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refMap",
 	},
 	"Secret": {
 		AllowedChoices: []string{},
@@ -695,6 +773,42 @@ var ListLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
 		Stored:         true,
 		Type:           "string",
 	},
+	"ref": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "ref",
+		ConvertedName:  "Ref",
+		Description:    `This attribute is a ref to a single object.`,
+		Filterable:     true,
+		Name:           "ref",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "ref",
+	},
+	"reflist": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "reflist",
+		ConvertedName:  "RefList",
+		Description:    `This attribute is a ref to a objects.`,
+		Filterable:     true,
+		Name:           "refList",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refList",
+	},
+	"refmap": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "refmap",
+		ConvertedName:  "RefMap",
+		Description:    `This attribute is a ref map to a objects.`,
+		Filterable:     true,
+		Name:           "refMap",
+		Orderable:      true,
+		Stored:         true,
+		SubType:        "task",
+		Type:           "refMap",
+	},
 	"secret": {
 		AllowedChoices: []string{},
 		BSONFieldName:  "secret",
@@ -821,6 +935,15 @@ type SparseList struct {
 	// This attribute is readonly.
 	ReadOnly *string `json:"readOnly,omitempty" msgpack:"readOnly,omitempty" bson:"readonly,omitempty" mapstructure:"readOnly,omitempty"`
 
+	// This attribute is a ref to a single object.
+	Ref *Task `json:"-" msgpack:"-" bson:"ref,omitempty" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref to a objects.
+	RefList *TasksList `json:"-" msgpack:"-" bson:"reflist,omitempty" mapstructure:"-,omitempty"`
+
+	// This attribute is a ref map to a objects.
+	RefMap *map[string]*Task `json:"-" msgpack:"-" bson:"refmap,omitempty" mapstructure:"-,omitempty"`
+
 	// This attribute is secret.
 	Secret *string `json:"secret,omitempty" msgpack:"secret,omitempty" bson:"secret,omitempty" mapstructure:"secret,omitempty"`
 
@@ -897,6 +1020,15 @@ func (o *SparseList) GetBSON() (any, error) {
 	if o.ReadOnly != nil {
 		s.ReadOnly = o.ReadOnly
 	}
+	if o.Ref != nil {
+		s.Ref = o.Ref
+	}
+	if o.RefList != nil {
+		s.RefList = o.RefList
+	}
+	if o.RefMap != nil {
+		s.RefMap = o.RefMap
+	}
 	if o.Secret != nil {
 		s.Secret = o.Secret
 	}
@@ -946,6 +1078,15 @@ func (o *SparseList) SetBSON(raw bson.Raw) error {
 	if s.ReadOnly != nil {
 		o.ReadOnly = s.ReadOnly
 	}
+	if s.Ref != nil {
+		o.Ref = s.Ref
+	}
+	if s.RefList != nil {
+		o.RefList = s.RefList
+	}
+	if s.RefMap != nil {
+		o.RefMap = s.RefMap
+	}
 	if s.Secret != nil {
 		o.Secret = s.Secret
 	}
@@ -992,6 +1133,15 @@ func (o *SparseList) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.ReadOnly != nil {
 		out.ReadOnly = *o.ReadOnly
+	}
+	if o.Ref != nil {
+		out.Ref = o.Ref
+	}
+	if o.RefList != nil {
+		out.RefList = *o.RefList
+	}
+	if o.RefMap != nil {
+		out.RefMap = *o.RefMap
 	}
 	if o.Secret != nil {
 		out.Secret = *o.Secret
@@ -1047,28 +1197,34 @@ func (o *SparseList) DeepCopyInto(out *SparseList) {
 }
 
 type mongoAttributesList struct {
-	ID           bson.ObjectId `bson:"_id,omitempty"`
-	CreationOnly string        `bson:"creationonly"`
-	Date         time.Time     `bson:"date"`
-	Description  string        `bson:"description"`
-	Name         string        `bson:"name"`
-	ParentID     string        `bson:"parentid"`
-	ParentType   string        `bson:"parenttype"`
-	ReadOnly     string        `bson:"readonly"`
-	Secret       string        `bson:"secret"`
-	Slice        []string      `bson:"slice"`
-	Unexposed    string        `bson:"unexposed"`
+	ID           bson.ObjectId    `bson:"_id,omitempty"`
+	CreationOnly string           `bson:"creationonly"`
+	Date         time.Time        `bson:"date"`
+	Description  string           `bson:"description"`
+	Name         string           `bson:"name"`
+	ParentID     string           `bson:"parentid"`
+	ParentType   string           `bson:"parenttype"`
+	ReadOnly     string           `bson:"readonly"`
+	Ref          *Task            `bson:"ref"`
+	RefList      TasksList        `bson:"reflist"`
+	RefMap       map[string]*Task `bson:"refmap"`
+	Secret       string           `bson:"secret"`
+	Slice        []string         `bson:"slice"`
+	Unexposed    string           `bson:"unexposed"`
 }
 type mongoAttributesSparseList struct {
-	ID           bson.ObjectId `bson:"_id,omitempty"`
-	CreationOnly *string       `bson:"creationonly,omitempty"`
-	Date         *time.Time    `bson:"date,omitempty"`
-	Description  *string       `bson:"description,omitempty"`
-	Name         *string       `bson:"name,omitempty"`
-	ParentID     *string       `bson:"parentid,omitempty"`
-	ParentType   *string       `bson:"parenttype,omitempty"`
-	ReadOnly     *string       `bson:"readonly,omitempty"`
-	Secret       *string       `bson:"secret,omitempty"`
-	Slice        *[]string     `bson:"slice,omitempty"`
-	Unexposed    *string       `bson:"unexposed,omitempty"`
+	ID           bson.ObjectId     `bson:"_id,omitempty"`
+	CreationOnly *string           `bson:"creationonly,omitempty"`
+	Date         *time.Time        `bson:"date,omitempty"`
+	Description  *string           `bson:"description,omitempty"`
+	Name         *string           `bson:"name,omitempty"`
+	ParentID     *string           `bson:"parentid,omitempty"`
+	ParentType   *string           `bson:"parenttype,omitempty"`
+	ReadOnly     *string           `bson:"readonly,omitempty"`
+	Ref          *Task             `bson:"ref,omitempty"`
+	RefList      *TasksList        `bson:"reflist,omitempty"`
+	RefMap       *map[string]*Task `bson:"refmap,omitempty"`
+	Secret       *string           `bson:"secret,omitempty"`
+	Slice        *[]string         `bson:"slice,omitempty"`
+	Unexposed    *string           `bson:"unexposed,omitempty"`
 }

--- a/test/model/task.go
+++ b/test/model/task.go
@@ -112,6 +112,9 @@ type Task struct {
 	// The type of the parent of the object.
 	ParentType string `json:"parentType" msgpack:"parentType" bson:"parenttype" mapstructure:"parentType,omitempty"`
 
+	// This attribute is secret.
+	Secret string `json:"secret" msgpack:"secret" bson:"secret" mapstructure:"secret,omitempty"`
+
 	// The status of the task.
 	Status TaskStatusValue `json:"status" msgpack:"status" bson:"status" mapstructure:"status,omitempty"`
 
@@ -162,6 +165,7 @@ func (o *Task) GetBSON() (any, error) {
 	s.Name = o.Name
 	s.ParentID = o.ParentID
 	s.ParentType = o.ParentType
+	s.Secret = o.Secret
 	s.Status = o.Status
 
 	return s, nil
@@ -185,6 +189,7 @@ func (o *Task) SetBSON(raw bson.Raw) error {
 	o.Name = s.Name
 	o.ParentID = s.ParentID
 	o.ParentType = s.ParentType
+	o.Secret = s.Secret
 	o.Status = s.Status
 
 	return nil
@@ -243,6 +248,7 @@ func (o *Task) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			Name:        &o.Name,
 			ParentID:    &o.ParentID,
 			ParentType:  &o.ParentType,
+			Secret:      &o.Secret,
 			Status:      &o.Status,
 		}
 	}
@@ -260,6 +266,8 @@ func (o *Task) ToSparse(fields ...string) elemental.SparseIdentifiable {
 			sp.ParentID = &(o.ParentID)
 		case "parentType":
 			sp.ParentType = &(o.ParentType)
+		case "secret":
+			sp.Secret = &(o.Secret)
 		case "status":
 			sp.Status = &(o.Status)
 		}
@@ -289,6 +297,9 @@ func (o *Task) Patch(sparse elemental.SparseIdentifiable) {
 	}
 	if so.ParentType != nil {
 		o.ParentType = *so.ParentType
+	}
+	if so.Secret != nil {
+		o.Secret = *so.Secret
 	}
 	if so.Status != nil {
 		o.Status = *so.Status
@@ -377,6 +388,8 @@ func (o *Task) ValueForAttribute(name string) any {
 		return o.ParentID
 	case "parentType":
 		return o.ParentType
+	case "secret":
+		return o.Secret
 	case "status":
 		return o.Status
 	}
@@ -455,6 +468,19 @@ var TaskAttributesMap = map[string]elemental.AttributeSpecification{
 		Name:           "parentType",
 		Orderable:      true,
 		ReadOnly:       true,
+		Stored:         true,
+		Type:           "string",
+	},
+	"Secret": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "secret",
+		ConvertedName:  "Secret",
+		Description:    `This attribute is secret.`,
+		Exposed:        true,
+		Filterable:     true,
+		Name:           "secret",
+		Orderable:      true,
+		Secret:         true,
 		Stored:         true,
 		Type:           "string",
 	},
@@ -544,6 +570,19 @@ var TaskLowerCaseAttributesMap = map[string]elemental.AttributeSpecification{
 		Name:           "parentType",
 		Orderable:      true,
 		ReadOnly:       true,
+		Stored:         true,
+		Type:           "string",
+	},
+	"secret": {
+		AllowedChoices: []string{},
+		BSONFieldName:  "secret",
+		ConvertedName:  "Secret",
+		Description:    `This attribute is secret.`,
+		Exposed:        true,
+		Filterable:     true,
+		Name:           "secret",
+		Orderable:      true,
+		Secret:         true,
 		Stored:         true,
 		Type:           "string",
 	},
@@ -640,6 +679,9 @@ type SparseTask struct {
 	// The type of the parent of the object.
 	ParentType *string `json:"parentType,omitempty" msgpack:"parentType,omitempty" bson:"parenttype,omitempty" mapstructure:"parentType,omitempty"`
 
+	// This attribute is secret.
+	Secret *string `json:"secret,omitempty" msgpack:"secret,omitempty" bson:"secret,omitempty" mapstructure:"secret,omitempty"`
+
 	// The status of the task.
 	Status *TaskStatusValue `json:"status,omitempty" msgpack:"status,omitempty" bson:"status,omitempty" mapstructure:"status,omitempty"`
 
@@ -701,6 +743,9 @@ func (o *SparseTask) GetBSON() (any, error) {
 	if o.ParentType != nil {
 		s.ParentType = o.ParentType
 	}
+	if o.Secret != nil {
+		s.Secret = o.Secret
+	}
 	if o.Status != nil {
 		s.Status = o.Status
 	}
@@ -735,6 +780,9 @@ func (o *SparseTask) SetBSON(raw bson.Raw) error {
 	if s.ParentType != nil {
 		o.ParentType = s.ParentType
 	}
+	if s.Secret != nil {
+		o.Secret = s.Secret
+	}
 	if s.Status != nil {
 		o.Status = s.Status
 	}
@@ -766,6 +814,9 @@ func (o *SparseTask) ToPlain() elemental.PlainIdentifiable {
 	}
 	if o.ParentType != nil {
 		out.ParentType = *o.ParentType
+	}
+	if o.Secret != nil {
+		out.Secret = *o.Secret
 	}
 	if o.Status != nil {
 		out.Status = *o.Status
@@ -820,6 +871,7 @@ type mongoAttributesTask struct {
 	Name        string          `bson:"name"`
 	ParentID    string          `bson:"parentid"`
 	ParentType  string          `bson:"parenttype"`
+	Secret      string          `bson:"secret"`
 	Status      TaskStatusValue `bson:"status"`
 }
 type mongoAttributesSparseTask struct {
@@ -828,5 +880,6 @@ type mongoAttributesSparseTask struct {
 	Name        *string          `bson:"name,omitempty"`
 	ParentID    *string          `bson:"parentid,omitempty"`
 	ParentType  *string          `bson:"parenttype,omitempty"`
+	Secret      *string          `bson:"secret,omitempty"`
 	Status      *TaskStatusValue `bson:"status,omitempty"`
 }

--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,15 @@ func RemoveZeroValues(obj any) {
 // object using reflection.
 func extractFieldNames(obj any) []string {
 
+	if obj == nil {
+		return []string{}
+	}
+
 	val := reflect.Indirect(reflect.ValueOf(obj))
+	if !val.IsValid() {
+		return []string{}
+	}
+
 	c := val.NumField()
 	fields := make([]string, c)
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -30,7 +30,7 @@ func TestUtils_extractFieldNames(t *testing.T) {
 			fields := extractFieldNames(l1)
 
 			Convey("Then all fields should be present", func() {
-				So(len(fields), ShouldEqual, 12)
+				So(len(fields), ShouldEqual, 15)
 				So(fields, ShouldContain, "ID")
 				So(fields, ShouldContain, "Description")
 				So(fields, ShouldContain, "Name")
@@ -43,6 +43,9 @@ func TestUtils_extractFieldNames(t *testing.T) {
 				So(fields, ShouldContain, "Slice")
 				So(fields, ShouldContain, "ModelVersion")
 				So(fields, ShouldContain, "Secret")
+				So(fields, ShouldContain, "Ref")
+				So(fields, ShouldContain, "RefList")
+				So(fields, ShouldContain, "RefMap")
 			})
 		})
 	})


### PR DESCRIPTION
Add StreamEncodingOptionSeparator() to define a separator between encodings. This allows for instance to make jsonl compatible encoding