### PR TITLE
fix: nil ref object getting initialized

### DIFF
--- a/cmd/elegen/templates/model.gotpl
+++ b/cmd/elegen/templates/model.gotpl
@@ -200,8 +200,8 @@ func (o *{{ .Spec.Model.EntityName }}) GetBSON() (any, error) {
 // This is used to transparently convert ID to MongoDBID as ObectID.
 func (o *{{ .Spec.Model.EntityName }}) SetBSON(raw bson.Raw) error {
 
-    if o == nil {
-        return nil
+    if o == nil || raw.Kind == bson.ElementNil {
+        return bson.ErrSetZero
     }
 
     s := &mongoAttributes{{ .Spec.Model.EntityName }}{}


### PR DESCRIPTION
This patch fixes a VERY long standing issue related to ref object being initialized while they were actually stored as nil after going to bson.Unmarshal.

The reason is that we must check if the raw.Kind is bson.ElementNil and if not we must return bson.ErrSetZero.

I found this while crusing the mgo code and it was definitely not obvious