### PR TITLE
fix: ref objects that are not pointers had wrong default value

### DIFF
--- a/cmd/elegen/utils.go
+++ b/cmd/elegen/utils.go
@@ -409,11 +409,16 @@ func writeDefaultValue(set spec.SpecificationSet, s spec.Specification, attr *sp
 		return attr.Initializer
 	}
 
-	var pointer string
+	var pointer, nopointer string
 	var ref string
-	if mode, ok := attr.Extensions["refMode"]; ok && mode == "pointer" {
-		pointer = "*"
+	if mode, ok := attr.Extensions["refMode"]; ok {
 		ref = "New"
+		switch mode {
+		case "pointer":
+			pointer = "*"
+		case "nopointer":
+			nopointer = "*"
+		}
 	}
 
 	switch attr.Type {
@@ -424,7 +429,7 @@ func writeDefaultValue(set spec.SpecificationSet, s spec.Specification, attr *sp
 		}
 
 	case spec.AttributeTypeRef:
-		return ref + set.Specification(attr.SubType).Model().EntityName + "()"
+		return nopointer + ref + set.Specification(attr.SubType).Model().EntityName + "()"
 
 	case spec.AttributeTypeRefList:
 		remoteSpec := set.Specification(attr.SubType)


### PR DESCRIPTION
So I had the issue that `ref` objects that did not have any `extensions` set generated the wrong default value within other objects. The intention was that `noinit` is **not** set, and that an init function must be generated. However, as any `refMode` extension was missing, it generated a completely wrong string: `StructName()`.

I changed the specs to explicitly have a a `refMode` extension with the `nopointer` value (as it is being used in other places already).

**NOTE:** @primalmotion I'm not sure this is the exact behaviour we want. It still means that we would generate the wrong thing if no extensions are being set at all! That said, I felt being explicit about the refMode is probably always a good idea anyways.