### PR TITLE
elegen: call elemental.ResetDefaultForZeroValue() on Validate()

### DIFF
--- a/cmd/elegen/templates/model.gotpl
+++ b/cmd/elegen/templates/model.gotpl
@@ -398,6 +398,8 @@ func (o *{{ .Spec.Model.EntityName }}) DeepCopyInto(out *{{ .Spec.Model.EntityNa
 // Validate valides the current information stored into the structure.
 func (o *{{ .Spec.Model.EntityName }}) Validate() error {
 
+    elemental.ResetDefaultForZeroValues(o)
+
     errors := elemental.Errors{}
     requiredErrors := elemental.Errors{}
 
@@ -446,13 +448,11 @@ func (o *{{ .Spec.Model.EntityName }}) Validate() error {
 
     {{ if eq .Type "ref" }}
     {{- if ne .Extensions.refMode "pointer" }}
-    elemental.ResetDefaultForZeroValues(o.{{ .ConvertedName }})
     if err := o.{{ .ConvertedName }}.Validate(); err != nil {
         errors = errors.Append(err)
     }
     {{ else }}
     if o.{{ .ConvertedName }} != nil {
-        elemental.ResetDefaultForZeroValues(o.{{ .ConvertedName }})
         if err := o.{{ .ConvertedName }}.Validate(); err != nil {
             errors = errors.Append(err)
         }
@@ -467,7 +467,6 @@ func (o *{{ .Spec.Model.EntityName }}) Validate() error {
             continue
         }
         {{ end -}}
-        elemental.ResetDefaultForZeroValues(sub)
         if err := sub.Validate(); err != nil {
             errors = errors.Append(err)
         }


### PR DESCRIPTION
Previously, ResetDefaultForZeroValue was only call on ref, refList etc in the validate function, assuming something would call it before.

This seem to be an actual very long running issue where zero values were not reseted anywhere in the code, and was simply assuming the client SDK would do it.

The entire idea to not call this on Validate, or during the write operation (right now it was only call on read operation) was to have the default evolve with the spec if it has never been set. This has never worked as the data was either init'ed to the default by the client SDK, or it would trigger a 422 required prop error anyways.

Better solidfy this logic here now.