### PR TITLE
elegen: detached are now elemental.Identifiable

### DIFF
--- a/cmd/elegen/templates/model.gotpl
+++ b/cmd/elegen/templates/model.gotpl
@@ -148,6 +148,11 @@ func (o *{{ .Spec.Model.EntityName }}) Identity() elemental.Identity {
 
     return {{ .Spec.Model.EntityName }}Identity
 }
+{{- else }}
+func (o *{{ .Spec.Model.EntityName }}) Identity() elemental.Identity {
+
+    return elemental.Identity{}
+}
 {{- end }}
 
 {{- if not .Spec.Model.Detached }}
@@ -160,6 +165,11 @@ func (o *{{ .Spec.Model.EntityName }}) Identifier() string {
     return ""
     {{- end }}
 }
+{{- else }}
+func (o *{{ .Spec.Model.EntityName }}) Identifier() string {
+
+	return ""
+}
 {{- end }}
 
 {{- if not .Spec.Model.Detached }}
@@ -169,6 +179,10 @@ func (o *{{ .Spec.Model.EntityName }}) SetIdentifier(id string) {
     {{ if .Spec.Identifier -}}
     o.{{ .Spec.Identifier.ConvertedName }} = id
     {{- end }}
+}
+{{- else }}
+func (o *{{ .Spec.Model.EntityName }}) SetIdentifier(id string) {
+	panic("you cannot set identifier on a detached object")
 }
 {{- end }}
 
@@ -221,13 +235,11 @@ func (o *{{ .Spec.Model.EntityName }}) SetBSON(raw bson.Raw) error {
     return nil
 }
 
-{{- if not .Spec.Model.Detached }}
 // Version returns the hardcoded version of the model.
 func (o *{{ .Spec.Model.EntityName }}) Version() int {
 
     return {{ .Set.APIInfo.Version }}
 }
-{{- end }}
 
 // BleveType implements the bleve.Classifier Interface.
 func (o *{{ .Spec.Model.EntityName }}) BleveType() string {
@@ -247,7 +259,6 @@ func (o *{{ .Spec.Model.EntityName  }}) DefaultOrder() []string {
 }
 {{- end }}
 
-{{- if not .Spec.Model.Detached }}
 {{ if .Spec.Model.Description }}
 // Doc returns the documentation for the object
 func (o *{{ .Spec.Model.EntityName }}) Doc() string {
@@ -255,7 +266,6 @@ func (o *{{ .Spec.Model.EntityName }}) Doc() string {
     return `{{ escBackticks .Spec.Model.Description }}`
 }
 {{ end }}
-{{- end }}
 
 {{- if not .Spec.Model.Detached }}
 func (o *{{ .Spec.Model.EntityName }}) String() string {


### PR DESCRIPTION
Detached did not implement identifiable interface. This was causing a tons of headeaches. Instead this patch makes detached implement the Identifiable interface, but returns an empty identity, empty identifier and panics if you call SetIdentifier